### PR TITLE
Admin can only see the pending OutreachEvents and VisitLogs

### DIFF
--- a/src/component/admin_test/PostApprovals.js
+++ b/src/component/admin_test/PostApprovals.js
@@ -38,7 +38,7 @@ const PostApprovals = () => {
         // Fetch outreaches
         const outreachQuery = query(
           collection(db, "outreachEvents"),
-          where("approved", "==", false)
+          where("status", "==", "pending")
         );
         const outreachSnapshot = await getDocs(outreachQuery);
         const outreaches = await Promise.all(
@@ -58,7 +58,7 @@ const PostApprovals = () => {
         // Fetch visit logs
         const visitLogQuery = query(
           collection(db, "personalVisitLog"),
-          where("approved", "==", false)
+          where("status", "==", "pending")
         );
         const visitLogSnapshot = await getDocs(visitLogQuery);
         const visitLogs = await Promise.all(


### PR DESCRIPTION
Admin can only see the pending OutreachEvents and VisitLogs, Previously all the Outreach events and the VisitLogs were visible.