### PR TITLE
Modifying pagination of user management

### DIFF
--- a/src/component/Admin/UserListNew.js
+++ b/src/component/Admin/UserListNew.js
@@ -52,6 +52,8 @@ export default function UserListNew() {
   const [usersPerPage] = useState(10);
   const [sorted, setSorted] = useState(initialSorted);
   const [chapterRoles, setChapterRoles] = useState({});
+  const startIndex = (currentPage - 1) * usersPerPage;
+  const endIndex = startIndex + usersPerPage;
 
 
   const isMobile = useMediaQuery("(max-width:767px)");
@@ -617,8 +619,9 @@ const changeUserType = async (email, docId, Type) => {
               }`}
             >
               <div>
-                Showing {usersPerPage} of {filteredUsers.length} users
+                Showing {startIndex + 1}–{Math.min(endIndex, filteredUsers.length)} of {filteredUsers.length} users
               </div>
+
               <div className="flex justify-between md:justify-end mt-6 items-center">
                 {currentPage === 1 ? (
                   <IoChevronBackCircle className="w-8 h-8 text-[#565656]" />


### PR DESCRIPTION
Asana task link: https://app.asana.com/1/1196658544911034/project/1209276506648499/task/1210457530063188?focus=true

**Before:**
On the `/admin/userManagement` page:
When filters result in fewer than 10 users, the bottom-left text says:  
  "Showing 10 of 1 users"— which is incorrect.
When navigating to the second page, same issue.

**Solution:**
Adjusted the logic that calculates and displays pagination count.

**After:**
When filtered users are less than 10, it now shows the correct count:
  e.g., `"Showing 1-2 out of 2 users"`.
Navigating to other pages reflects accurate count ranges.

