### PR TITLE
visitLogWebProd: rename collection to visitLogsBookNew & refactor field names

### DIFF
--- a/src/component/Community/MoreVisitLogs.js
+++ b/src/component/Community/MoreVisitLogs.js
@@ -26,6 +26,7 @@ import { getAuth } from "firebase/auth";
 import collectionMapping from "../../utils/firestoreCollections";
 
 const visitLogs_collection = collectionMapping.visitLogs;
+const visitLogsNew_collection = collectionMapping.visitLogsBookNew;
 
 const MoreVisitLogs = () => {
   const [visitLogs, setVisitLogs] = useState([]);
@@ -79,7 +80,7 @@ const MoreVisitLogs = () => {
 
   const updateFlagStatusInFirebase = async (id, flagged) => {
     try {
-      const logRef = doc(db, visitLogs_collection, id); // Correct Firestore reference
+      const logRef = doc(db, visitLogsNew_collection, id); // Correct Firestore reference
       await updateDoc(logRef, { flagged });
       console.log(`Flag status updated for log ID: ${id}, flagged: ${flagged}`);
     } catch (error) {

--- a/src/component/Community/OutreachVisitLogCard.js
+++ b/src/component/Community/OutreachVisitLogCard.js
@@ -19,6 +19,7 @@ import { useUserContext } from "../../context/Usercontext.js";
 import collectionMapping from "../../utils/firestoreCollections.js";
 
 const visitLogs_collection = collectionMapping.visitLogs;
+const visitLogsNew_collection = collectionMapping.visitLogsBookNew;
 const users_collection = collectionMapping.users; // User collection
 
 const OutreachVisitLogCard = ({ visitLogCardData }) => {
@@ -35,7 +36,7 @@ const OutreachVisitLogCard = ({ visitLogCardData }) => {
     try {
       
       if (visitLogCardData?.id) {
-        const docRef = doc(db, visitLogs_collection, visitLogCardData.id);
+        const docRef = doc(db, visitLogsNew_collection, visitLogCardData.id);
         const docSnap = await getDoc(docRef);
         if (docSnap.exists()) {
           setIsFlagged(docSnap.data().isFlagged || false);
@@ -93,7 +94,7 @@ const OutreachVisitLogCard = ({ visitLogCardData }) => {
       }
 
       const { Type: userType } = userDoc.data();
-      const docRef = doc(db, visitLogs_collection, visitLogCardData?.id);
+      const docRef = doc(db, visitLogsNew_collection, visitLogCardData?.id);
       const docSnap = await getDoc(docRef);
   
       if (!docSnap.exists()) {
@@ -183,10 +184,10 @@ const OutreachVisitLogCard = ({ visitLogCardData }) => {
         <div className="flex items-center">
           <img className="w-3 h-4" src={locationIcon} alt="Location" />
           <span className="ml-2 text-sm">
-            {`${visitLogCardData?.location?.city || visitLogCardData?.city}, ${
-              visitLogCardData?.location?.stateAbbv ||
-              visitLogCardData?.stateAbbv ||
-              visitLogCardData?.location?.state
+            {`${visitLogCardData?.location?.whereVisit || visitLogCardData?.whereVisit}, ${
+              visitLogCardData?.location?.whereVisit ||
+              visitLogCardData?.whereVisit ||
+              visitLogCardData?.location?.whereVisit
             }`}
           </span>
         </div>
@@ -195,7 +196,7 @@ const OutreachVisitLogCard = ({ visitLogCardData }) => {
       <div className="flex justify-between items-center mt-4">
         <div className="text-sm font-bold">People Helped</div>
         <div className="text-xl font-bold">
-          {visitLogCardData?.numberPeopleHelped}
+          {visitLogCardData?.numberOfHelpers}
         </div>
       </div>
       
@@ -209,7 +210,7 @@ const OutreachVisitLogCard = ({ visitLogCardData }) => {
       </div>
       
       <p className="text-sm mt-2 line-clamp-2">
-        {visitLogCardData?.description || ""}
+        {visitLogCardData?.peopleHelpedDescription || ""}
       </p>
     </div>
   );

--- a/src/component/Community/OutreachVisitLogProfileCard.js
+++ b/src/component/Community/OutreachVisitLogProfileCard.js
@@ -22,6 +22,7 @@ import collectionMapping from "../../utils/firestoreCollections";
 
 const users_collection = collectionMapping.users;
 const visitLogs_collection = collectionMapping.visitLogs;
+const visitLogsNew_collection = collectionMapping.visitLogsBookNew;
 
 const OutreachVisitLogProfileCard = ({ visitLogCardData, onRefresh }) => {
   const navigate = useNavigate();
@@ -32,7 +33,7 @@ const OutreachVisitLogProfileCard = ({ visitLogCardData, onRefresh }) => {
   // Function to delete visit log
   const deleteVisitLog = async () => {
     try {
-      const visitLogDoc = doc(db, visitLogs_collection, visitLogCardData.id);
+      const visitLogDoc = doc(db, visitLogsNew_collection, visitLogCardData.id);
 
       const userQuery = query(
         collection(db, users_collection),
@@ -118,7 +119,7 @@ const OutreachVisitLogProfileCard = ({ visitLogCardData, onRefresh }) => {
               <img alt="" className="w-4 h-4" src={calendar} />
               <div className="px-1">
                 {formatDate(
-                  new Date(visitLogCardData?.dateTime?.seconds * 1000)
+                  new Date(visitLogCardData?.whenVisit?.seconds * 1000)
                 )}
               </div>
             </div>
@@ -126,8 +127,8 @@ const OutreachVisitLogProfileCard = ({ visitLogCardData, onRefresh }) => {
             <div className="my-Location flex flex-row pt-2.5">
               <img alt="" className="w-4 h-4" src={location} />
               <div className="pt-0">
-                {visitLogCardData?.city || ""},{" "}
-                {visitLogCardData?.stateAbbv || visitLogCardData?.state || ""}
+                {visitLogCardData?.whereVisit || ""},{" "}
+                {visitLogCardData?.whereVisit || visitLogCardData?.whereVisit || ""}
               </div>
             </div>
           </div>
@@ -185,7 +186,7 @@ const OutreachVisitLogProfileCard = ({ visitLogCardData, onRefresh }) => {
           </div>
         </div>
         <div className="text-zinc-700 text-xl text-[12px] font-normal font-bricolage leading-snug mt-2 mb-2 px-1">
-          {visitLogCardData.description || ""}
+          {visitLogCardData.peopleHelpedDescription || ""}
         </div>
         <div className="flex flex-col gap-0.5">
           <div className="flex justify-between mt-2 mb-2 px-1">
@@ -193,7 +194,7 @@ const OutreachVisitLogProfileCard = ({ visitLogCardData, onRefresh }) => {
               People Helped
             </div>
             <div className="text-neutral-900 text-[18px] mt-[-5px] font-bold font-bricolage leading-tight text-right">
-              {visitLogCardData.numberPeopleHelped || ""}
+              {visitLogCardData.numberOfHelpers || ""}
             </div>
           </div>
           <div className="flex justify-between mt-2 mb-2 px-1">


### PR DESCRIPTION

- Renamed collection:
  - `visitLogWebProd` → `visitLogsBookNew`
- Refactored several fields:
  - `street`, `city`, `stateAbbv`, `zip` → `whereVisit`
  - `numberPeopleHelped` → `numberOfHelpers`
  - `description` → `peopleHelpedDescription `

Files changed:
street_care_webapp\src\component\UserProfile\MoreVisitLogs.js
street_care_webapp\src\component\UserProfile\OutreachVisitLogCard.js
street_care_webapp\src\component\UserProfile\OutreachVisitLogProfileCard.js