### PR TITLE
Auto-hide liked section + instant unlike

### DIFF
--- a/src/component/Community/OutreachEventCard.js
+++ b/src/component/Community/OutreachEventCard.js
@@ -27,6 +27,7 @@ const OutreachEventCard = ({
   cardData,
   isProfilePage,
   isHelpRequestCard,
+  onUpdate, // NEW: parent refresh callback
 }) => {
   const { user } = useUserContext();
   const {
@@ -158,6 +159,26 @@ const OutreachEventCard = ({
       setJustCopied(false);
     }
   };
+const handleLikeToggle = async (e) => {
+  e.stopPropagation();
+  try {
+    await handleLikes(
+      e,
+      id,
+      navigate,
+      isLiked ? "DISLIKE" : "LIKE",
+      setIsLiked,
+      setLikesCount,
+      false
+    );
+    // Tell parent to refresh (this will hide the section when last like is removed)
+    if (isProfilePage && typeof onUpdate === "function") {
+      onUpdate();
+    }
+  } catch (err) {
+    console.error("Toggle like failed:", err);
+  }
+};
 
   let verifiedImg;
   switch (userType) {
@@ -190,21 +211,14 @@ const OutreachEventCard = ({
             {likesCount}
           </div>
         )}
+
         {/* Like Button */}
         <img
-          onClick={(e) => handleLikes(
-            e,
-            id,
-            navigate,
-            isLiked ? "DISLIKE" :"LIKE",
-            setIsLiked,
-            setLikesCount,
-            false
-          )}
-          src={isLiked ? heartFilled : heartOutline}
-          alt="like"
-          className="w-8 h-8 cursor-pointer rounded-full p-1 hover:bg-gray-200"
-        />
+  onClick={handleLikeToggle}
+  src={isLiked ? heartFilled : heartOutline}
+  alt="like"
+  className="w-8 h-8 cursor-pointer rounded-full p-1 hover:bg-gray-200"
+/>
 
         {/* Share Button */}
         <div className="relative">

--- a/src/component/UserProfile/Profile.js
+++ b/src/component/UserProfile/Profile.js
@@ -173,74 +173,52 @@ function Profile() {
           </div>{" "}
         </div>
 
-        {/* Liked Outreaches section */}
-
-        <div className="  w-[95%] md:w-[90%] lg:w-[80%] mx-2 lg:mx-40 mt-8 rounded-2xl bg-white text-black mb-10">
-          <div className="flex flex-col gap-4 md:px-12 md:py-16 lg:gap-14 lg:p-24 pl-8 pt-4 pb-4 pr-8">
-            <div className="inline-flex flex-col sm:flex-row sm:space-x-16 justify-between gap-2">
-              <div class="text-neutral-800 text-4xl lg:text-5xl font-medium font-bricolage text-left leading-[52px]">
-                Liked Outreaches
-              </div>
-              <CustomButton
-              label="More Liked Outreaches"
-              name="buttondefault"
-              onClick={() => {
-                navigate("/profile/allLikedOutreaches");
-              }}
-            />
-            </div>
-            {/* <div className="pt-4">
-              <div className="w-full flex flex-col sm:flex-row bg-[#F2F6D8] p-4 rounded-xl gap-4 justify-between">
-                <div className="text-neutral-800  text-[20px] font-medium font-bricolage leading-loose">
-                  Now you can view your created outreach events.
-                </div>
-              </div>
-            </div> */}
-
-            <div className="block overflow-x-auto overflow-y-hidden">
-              {isLoading ? (
-                <div className="flex justify-between items-center w-full h-fit gap-2">
-                  <EventCardSkeleton />
-                  <EventCardSkeleton />
-                  <EventCardSkeleton />
-                </div>
-              ) : likedEvents.length === 0 ? (
-                <NoDisplayData
-                  name="likedoutreaches"
-                  label="No outreach events liked"
-                />
-              ) : (
-                <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-2 mb-6">
-                  {likedEvents.slice(0,3).map((eventData) => (
-                    <OutreachEventCard
-                      key={eventData.id}
-                      cardData={{
-                        ...eventData,
-                        eventDate: formatDate(
-                          new Date(eventData.eventDate.seconds * 1000)
-                        ),
-                      }}
-                      isProfilePage={true}
-                      refresh={fetchData}
-                      openModal={() =>
-                        openModal({
-                          ...eventData,
-                          eventDate: eventData.eventDate?.seconds
-                            ? formatDate(
-                                new Date(eventData.eventDate.seconds * 1000)
-                              )
-                            : eventData.eventDate,
-                        })
-                      }
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>{" "}
+       {/* Liked Outreaches section */}
+{!isLoading && likedEvents.length > 0 && (
+  <div className="w-[95%] md:w-[90%] lg:w-[80%] mx-2 lg:mx-40 mt-8 rounded-2xl bg-white text-black mb-10">
+    <div className="flex flex-col gap-4 md:px-12 md:py-16 lg:gap-14 lg:p-24 pl-8 pt-4 pb-4 pr-8">
+      <div className="inline-flex flex-col sm:flex-row sm:space-x-16 justify-between gap-2">
+        <div className="text-neutral-800 text-4xl lg:text-5xl font-medium font-bricolage text-left leading-[52px]">
+          Liked Outreaches
         </div>
+        <CustomButton
+          label="More Liked Outreaches"
+          name="buttondefault"
+          onClick={() => {
+            navigate("/profile/allLikedOutreaches");
+          }}
+        />
+      </div>
 
-
+      <div className="block overflow-x-auto overflow-y-hidden">
+        <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-2 mb-6">
+          {likedEvents.slice(0, 3).map((eventData) => (
+            <OutreachEventCard
+              key={eventData.id}
+              cardData={{
+                ...eventData,
+                eventDate: formatDate(
+                  new Date((eventData.eventDate?.seconds ?? 0) * 1000)
+                ),
+              }}
+              isProfilePage={true}
+              refresh={fetchData}
+              onUpdate={fetchData}  // NEW: triggers auto re-fetch after unlike
+              openModal={() =>
+                openModal({
+                  ...eventData,
+                  eventDate: eventData.eventDate?.seconds
+                    ? formatDate(new Date(eventData.eventDate.seconds * 1000))
+                    : eventData.eventDate,
+                })
+              }
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  </div>
+)}
         {/* Created outreaches section */}
 
         <div className="  w-[95%] md:w-[90%] lg:w-[80%] mx-2 lg:mx-40 mt-8 rounded-2xl bg-white text-black mb-10">


### PR DESCRIPTION
Updated the code to enhance the 'Liked Events' section behavior. Now, when a user unlikes an event, the corresponding event card is immediately removed from the view, and if there are no remaining liked events, the entire section is automatically hidden. This ensures real-time UI updates and a cleaner user experience without requiring a manual page refresh.