### PR TITLE
Add contact phone and email under footer social icons

### DIFF
--- a/src/component/Footer.js
+++ b/src/component/Footer.js
@@ -88,6 +88,13 @@ function Footer() {
                 </div>
               </li>
               <li className="mb-4">
+                <p className=" font-inter text-sm text-white whitespace-nowrap">
+                  <a href="tel:3477191134" className="hover:underline">(347) 719-1134</a>
+                  <span className="mx-2">|</span>
+                  <a href="mailto:info@streetcare.us" className="hover:underline">info@streetcare.us</a>
+                </p>
+              </li>
+              <li className="mb-4">
                 <p className=" font-inter text-xs">
                   (c) Bright Mind Enrichment and Schooling {new Date().getFullYear()} Street Care is a
                   community wellness initiative of Bright Mind, a 501(c)(3)


### PR DESCRIPTION
## Summary
- Add official contact phone and email to the homepage footer
- Mirrors the footer on https://streetcare.us/ for consistency

## Changes Made
- Update `src/component/Footer.js` to show `(347) 719-1134` and `info@streetcare.us` below social icons
- Use `tel:` and `mailto:` links with simple underline hover style

## Test Plan
- Static JSX change; renders plain text/links under the social icon row
- Verified links format and classes match existing footer styles

Fixes #498