### PR TITLE
Added Voicemail Option 

### DIFF
--- a/src/component/UserProfile/PersonalOutForm.js
+++ b/src/component/UserProfile/PersonalOutForm.js
@@ -873,13 +873,13 @@ function PersonalOutForm() {
               <div className="flex-col justify-start items-start gap-4 md:gap-16 flex px-4 py-4 md:px-0 md:py-0">
                 <div className="w-fit text-neutral-800 md:text-[57px] font-medium font-bricolage md:leading-[64px] text-[32px] leading-[40px]">
                   Tell us about who you helped!
-                <div>
-                  Voicemail Option: If you are unable to complete the Interaction Log Form at the time 
-                  of the encounter, you may leave a voicemail at <span className="font-bold">347-719-1134</span>.  
-                  Please note: completing the form remains the preferred method, as it ensures that all 
-                  aspects of the interaction are recorded accurately.
-                  </div>  
                 </div>
+                <p className="self-stretch font-bricolage text-[18px]">
+                  <span className="font-bold">Voicemail Option:</span> If you are unable to complete the Interaction Log Form 
+                  at the time of the encounter, you may leave a voicemail at 
+                  <span className="font-bold"> 347-719-1134</span>. Please note: completing the form remains the 
+                  preferred method, as it ensures that all aspects of the interaction are recorded accurately.
+                  </p>
                 <div className="self-stretch h-fit flex-col justify-center items-start gap-[24px] flex">
                   <div className="self-stretch h-fit flex-col justify-center items-start gap-[18px] flex">
                     <div className="self-stretch text-neutral-800 text-[16px] md:text-[22px] font-bold font-bricolage leading-7">


### PR DESCRIPTION
Add the phone number 347 719 1134 in the Interaction Log Form, to provide an option for a voice mail as an option instead of filling the form. We should proceed with one of the format below:

Used for top of the form before starting (after the title, before description).
Voicemail Option
If you are unable to complete the Interaction Log Form at the time of the encounter, you may leave a voicemail at 347-719-1134.
Please note: completing the form remains the preferred method, as it ensures that all aspects of the interaction are recorded accurately.

Also remove 'more' from the interaction log title.
New title is 'Tell us about who you helped!'