### PR TITLE
Bug 513: Interaction log and outreach events must show all status entities not just approved.

### DIFF
--- a/src/component/Community/OutreachEventCard.js
+++ b/src/component/Community/OutreachEventCard.js
@@ -19,6 +19,7 @@ import heartOutline from "../../images/heart-outline.png";
 import heartFilled from "../../images/heart-filled.png";
 import share from "../../images/share-icon.png";
 import { handleLikes, setInitialLike } from "../EventCardService";
+import {getStatusStyle} from "../../component/admin_test/ApprovalCardOutreachEvents.js";
 
 const outreachEvents_collection = collectionMapping.outreachEvents; // Collection name
 const users_collection = collectionMapping.users; // User collection
@@ -41,6 +42,7 @@ const OutreachEventCard = ({
     skills,
     userType,
     likes,
+    status,
   } = cardData;
 
   const navigate = useNavigate();
@@ -71,6 +73,7 @@ const OutreachEventCard = ({
 
         if (currentDoc.exists()) {
           const { isFlagged } = currentDoc.data();
+          console.log("CurrentDoc.data()",currentDoc.data());
           setIsFlagged(isFlagged || false);
         } else {
           console.error("Document does not exist:", id);
@@ -255,7 +258,16 @@ const handleLikeToggle = async (e) => {
         </div>
       </div>
 
-
+{/* Status */}
+      <div className="mt-2 text-right mb-2">
+        <span
+          className={`px-3 py-1 text-sm font-medium rounded-full ${getStatusStyle(
+            cardData.status
+          )}`}
+        >
+          {cardData.status || "No Status"}
+        </span>
+      </div>
       {/* User Information */}
       <div className="inline-flex items-center space-x-2">
         <img

--- a/src/component/Community/OutreachVisitLogProfile.js
+++ b/src/component/Community/OutreachVisitLogProfile.js
@@ -36,7 +36,8 @@ const OutreachVisitLogProfile = () => {
           cursorFields.pageHistory
         );
         setCursorFields((prev)=>({...prev,lastVisible:logs.lastVisible,pageHistory:logs.pageHistory}))
-        setVisitLogs(logs.visitLogs);
+        setVisitLogs(logs.visitLogs);        
+       console.log("Finding approved",visitLogs.some(log => log.approved === true)); 
         if(cursorFields.direction ==="next")setCurrentPageLength((prev)=>prev+logs.visitLogs.length)
         setIsLoading(false);
       } catch (error) {

--- a/src/component/Community/OutreachVisitLogProfileCard.js
+++ b/src/component/Community/OutreachVisitLogProfileCard.js
@@ -19,6 +19,7 @@ import DeleteModal from "./DeleteModal";
 import { formatDate } from "./../HelperFunction";
 
 import collectionMapping from "../../utils/firestoreCollections";
+import {getStatusStyle} from "../../component/admin_test/ApprovalCardOutreachEvents"
 
 const users_collection = collectionMapping.users;
 //const visitLogs_collection = collectionMapping.visitLogs; using new collection
@@ -113,6 +114,18 @@ const OutreachVisitLogProfileCard = ({ visitLogCardData, onRefresh }) => {
       }}
     >
       <div className="bg-[#F5EEFE] min-w-full max-w-[320px] lg:w-full rounded-[30px] flex flex-col justify-between">
+              {/* Adding pending status tag=>START,Niharika */}
+              {/* Status */}
+      <div className="mt-2 text-right mb-2">
+        <span
+          className={`px-3 py-1 text-sm font-medium rounded-full ${getStatusStyle(
+            visitLogCardData.status
+          )}`}
+        >
+          {visitLogCardData.status || "No Status"}
+        </span>
+      </div>
+      {/* Adding pending status tag=>END,Niharika */}
         <div className="flex justify-between items-center">
           <div className="text-violet-900 text-[12px] font-medium font-bricolage leading-tight flex flex-col">
             <div className="my-Custom-Date flex flex-row">

--- a/src/component/EventCardService.js
+++ b/src/component/EventCardService.js
@@ -1314,6 +1314,7 @@ export const fetchUserOutreaches = async () => {
     );
 
     const eventSnapshot = await getDocs(userQuery);
+    console.log("Eventsnapshot",eventSnapshot);
     let userOutreaches = [];
 
     for (const doc of eventSnapshot.docs) {
@@ -1333,7 +1334,7 @@ export const fetchUserOutreaches = async () => {
         userType: result.userType,
       });
     }
-
+console.log("Printing userOutreaches",userOutreaches);
     return userOutreaches;
   } catch (error) {
     logEvent(

--- a/src/component/UserProfile/CreatedOutreaches.js
+++ b/src/component/UserProfile/CreatedOutreaches.js
@@ -28,6 +28,7 @@ function CreatedOutreaches() {
         createdEventsData.sort((a, b) => a.eventDate - b.eventDate);
         
         setCreatedEvents(createdEventsData);
+        console.log("Fetched Outreach createdEventsData",createdEventsData);
       } else {
         console.log("No user is signed in");
         setCreatedEvents([]);

--- a/src/component/VisitLogCardService.js
+++ b/src/component/VisitLogCardService.js
@@ -95,7 +95,8 @@ export const fetchPersonalVisitLogss = async (
   try {
     let personalVisitLogRef = query(
       collection(db, visitLogsNew_collection),
-      where("status", "==", "approved"),
+      //where("status", "==", "approved"),
+      where("status", "in", ["approved","pending","rejected"]),
       where("uid", "==", uid),
       orderBy("timeStamp", "desc")
     );
@@ -149,7 +150,8 @@ export const PersonalVisitLogsCount = async (uid) => {
 
     totalVisitLogRef = query(
       collection(db, visitLogsNew_collection),
-      where("status", "==", "approved"),
+      //where("status", "==", "approved"),
+      where("status", "in", ["approved","pending"]),
       where("uid", "==", uid),
       orderBy("timeStamp", "desc")
     );

--- a/src/component/admin_test/ApprovalCardOutreachEvents.js
+++ b/src/component/admin_test/ApprovalCardOutreachEvents.js
@@ -20,7 +20,7 @@ const getTags = (postData, isVisitLogs) => {
   ));
 };
 
-const getStatusStyle = (status) => {
+export const getStatusStyle = (status) => {
   switch (status) {
     case "approved":
       return "bg-green-100 text-green-600 border border-green-600";


### PR DESCRIPTION
**Issue before change:** User was not able to view outreach events or interaction logs created by him/her unless they're acted on by an admin.

**Before:** In My profile ,outreach and interaction log section ,only approved items were visible.

**Changes made:** In My profile, now status of an outreach event or an interaction log will be shown to differentiate between different states. All available statues (APPROVED,PENDING,REJECTED) of outreach event and interaction logs will be shown under their respective sections in the event card. 
