### PR TITLE
Add modular pagination service

### DIFF
--- a/src/__tests__/utils/paginationService.test.js
+++ b/src/__tests__/utils/paginationService.test.js
@@ -1,19 +1,18 @@
-import { buildPaginatedQuery } from "../../utils/buildPaginatedQuery";
+import {
+  buildPaginatedQuery,
+  getNearestCachedPageBefore,
+} from "../../utils/buildPaginatedQuery";
 import { getPageCheckpoint } from "../../utils/getPageCheckpoint";
 import { createPaginationRequest } from "../../services/paginationService";
 import { limit, query, startAfter, startAt } from "firebase/firestore";
 
-// Mock only Firestore query builders. These tests verify cursor decisions,
-// not live Firebase reads or Firestore index behavior.
-// Example: startAfter(doc) returns a plain object so we can assert the cursor.
+// Mock Firestore query builders. The tests verify cursor decisions and
+// checkpoint behavior without hitting live Firebase.
 jest.mock("firebase/firestore", () => ({
-  limit: jest.fn((n) => ({ type: "limit", n })),
-  query: jest.fn((baseQuery, ...constraints) => ({
-    baseQuery,
-    constraints,
-  })),
-  startAfter: jest.fn((doc) => ({ type: "startAfter", doc })),
-  startAt: jest.fn((doc) => ({ type: "startAt", doc })),
+  limit: jest.fn(),
+  query: jest.fn(),
+  startAfter: jest.fn(),
+  startAt: jest.fn(),
 }));
 
 const PAGE_SIZE = 6;
@@ -25,9 +24,18 @@ const makeDocsForPage = (page) =>
 
 const makeCheckpointForPage = (page) => getPageCheckpoint(makeDocsForPage(page));
 
+const resetFirestoreMocks = () => {
+  limit.mockImplementation((n) => ({ type: "limit", n }));
+  query.mockImplementation((queryBase, ...constraints) => ({
+    baseQuery: queryBase,
+    constraints,
+  }));
+  startAfter.mockImplementation((doc) => ({ type: "startAfter", doc }));
+  startAt.mockImplementation((doc) => ({ type: "startAt", doc }));
+};
+
 describe("getPageCheckpoint", () => {
   test("returns first and last docs for a page", () => {
-    // Plain objects are enough here because the helper only stores snapshots.
     // Example: six fake docs produce firstDoc = doc 1 and lastDoc = doc 6.
     const checkpoint = getPageCheckpoint(makeDocsForPage(0));
 
@@ -47,9 +55,25 @@ describe("getPageCheckpoint", () => {
   });
 });
 
+describe("getNearestCachedPageBefore", () => {
+  test("returns the nearest cached page before the requested page", () => {
+    const checkpoints = {
+      0: makeCheckpointForPage(0),
+      2: makeCheckpointForPage(2),
+    };
+
+    expect(getNearestCachedPageBefore(5, checkpoints)).toBe(2);
+  });
+
+  test("returns null when no previous page is cached", () => {
+    expect(getNearestCachedPageBefore(5, {})).toBeNull();
+  });
+});
+
 describe("buildPaginatedQuery", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetFirestoreMocks();
   });
 
   test("builds first page query without a cursor", () => {
@@ -63,15 +87,15 @@ describe("buildPaginatedQuery", () => {
     expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
     expect(startAt).not.toHaveBeenCalled();
     expect(startAfter).not.toHaveBeenCalled();
-    expect(result.pageToCache).toBe(0);
-    expect(result.isTargetPage).toBe(true);
+    expect(result.pageQuery).toBeDefined();
+    expect(result.isTargetPage).toBeUndefined();
   });
 
   test("builds cached page query with startAt", () => {
-    // Example: if page 1 is cached, we can fetch it directly from its first doc.
+    // Example: if page 1 is cached, fetch it directly from its first doc.
     const pageOneCheckpoint = makeCheckpointForPage(1);
 
-    const result = buildPaginatedQuery({
+    buildPaginatedQuery({
       baseQuery,
       page: 1,
       pageSize: PAGE_SIZE,
@@ -82,81 +106,23 @@ describe("buildPaginatedQuery", () => {
 
     expect(startAt).toHaveBeenCalledWith(pageOneCheckpoint.firstDoc);
     expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
-    expect(result.pageToCache).toBe(1);
-    expect(result.isTargetPage).toBe(true);
   });
 
-  test("builds next missing page query with nearest previous checkpoint", () => {
-    // Example: page 1 is fetched with startAfter(page 0's last doc).
-    const pageZeroCheckpoint = makeCheckpointForPage(0);
+  test("builds missing page query from nearest previous checkpoint", () => {
+    // Example: page 3 with page 2 cached uses startAfter(page 2's last doc).
+    const pageTwoCheckpoint = makeCheckpointForPage(2);
 
-    const result = buildPaginatedQuery({
-      baseQuery,
-      page: 1,
-      pageSize: PAGE_SIZE,
-      pageCheckpoints: {
-        0: pageZeroCheckpoint,
-      },
-    });
-
-    expect(startAfter).toHaveBeenCalledWith(pageZeroCheckpoint.lastDoc);
-    expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
-    expect(result.pageToCache).toBe(1);
-    expect(result.isTargetPage).toBe(true);
-  });
-
-  test("returns the first missing page when target page is not reachable yet", () => {
-    // With no checkpoints, page 2 cannot be fetched directly. The service asks
-    // the hook to fetch and cache page 0 first.
-    const result = buildPaginatedQuery({
-      baseQuery,
-      page: 2,
-      pageSize: PAGE_SIZE,
-      pageCheckpoints: {},
-    });
-
-    expect(startAfter).not.toHaveBeenCalled();
-    expect(result.pageToCache).toBe(0);
-    expect(result.isTargetPage).toBe(false);
-  });
-
-  test("continues from the nearest cached page while jumping forward", () => {
-    // The target is page 3, but page 2 is the next missing page after cache.
-    const pageZeroCheckpoint = makeCheckpointForPage(0);
-    const pageOneCheckpoint = makeCheckpointForPage(1);
-
-    const result = buildPaginatedQuery({
+    buildPaginatedQuery({
       baseQuery,
       page: 3,
       pageSize: PAGE_SIZE,
       pageCheckpoints: {
-        0: pageZeroCheckpoint,
-        1: pageOneCheckpoint,
-      },
-    });
-
-    expect(startAfter).toHaveBeenCalledWith(pageOneCheckpoint.lastDoc);
-    expect(result.pageToCache).toBe(2);
-    expect(result.isTargetPage).toBe(false);
-  });
-
-  test("skips older checkpoints and starts after the nearest cached page", () => {
-    const pageZeroCheckpoint = makeCheckpointForPage(0);
-    const pageTwoCheckpoint = makeCheckpointForPage(2);
-
-    const result = buildPaginatedQuery({
-      baseQuery,
-      page: 4,
-      pageSize: PAGE_SIZE,
-      pageCheckpoints: {
-        0: pageZeroCheckpoint,
         2: pageTwoCheckpoint,
       },
     });
 
     expect(startAfter).toHaveBeenCalledWith(pageTwoCheckpoint.lastDoc);
-    expect(result.pageToCache).toBe(3);
-    expect(result.isTargetPage).toBe(false);
+    expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
   });
 
   test("throws for negative pages", () => {
@@ -173,63 +139,110 @@ describe("buildPaginatedQuery", () => {
 describe("createPaginationRequest", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetFirestoreMocks();
   });
 
-  test("returns a page query and resolves docs into updated checkpoints", () => {
-    // The hook will fetch request.pageQuery, then pass snapshot.docs to resolve.
-    // Example: resolving six docs caches page 0 as { firstDoc, lastDoc }.
-    const request = createPaginationRequest({
+  test("fills missing checkpoints up to the page before the requested page", async () => {
+    // Pages 0-2 are cached. Requesting page 5 should fetch pages 3 and 4 only.
+    const pageZeroCheckpoint = makeCheckpointForPage(0);
+    const pageOneCheckpoint = makeCheckpointForPage(1);
+    const pageTwoCheckpoint = makeCheckpointForPage(2);
+    const fetchDocs = jest
+      .fn()
+      .mockResolvedValueOnce(makeDocsForPage(3))
+      .mockResolvedValueOnce(makeDocsForPage(4));
+
+    const result = await createPaginationRequest({
       baseQuery,
-      page: 0,
+      page: 5,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {
+        0: pageZeroCheckpoint,
+        1: pageOneCheckpoint,
+        2: pageTwoCheckpoint,
+      },
+      fetchDocs,
+    });
+
+    expect(fetchDocs).toHaveBeenCalledTimes(2);
+    expect(result.pageCheckpoints[3].firstDoc.id).toBe("page-3-doc-1");
+    expect(result.pageCheckpoints[3].lastDoc.id).toBe("page-3-doc-6");
+    expect(result.pageCheckpoints[4].firstDoc.id).toBe("page-4-doc-1");
+    expect(result.pageCheckpoints[4].lastDoc.id).toBe("page-4-doc-6");
+    expect(startAfter).toHaveBeenLastCalledWith(
+      result.pageCheckpoints[4].lastDoc,
+    );
+    expect(result.pageQuery).toBeDefined();
+    expect(result.reachedEnd).toBe(false);
+    expect(result.isTargetPage).toBeUndefined();
+  });
+
+  test("does not fetch intermediate pages when the requested page is already cached", async () => {
+    const pageTwoCheckpoint = makeCheckpointForPage(2);
+    const fetchDocs = jest.fn();
+
+    const result = await createPaginationRequest({
+      baseQuery,
+      page: 2,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {
+        2: pageTwoCheckpoint,
+      },
+      fetchDocs,
+    });
+
+    expect(fetchDocs).not.toHaveBeenCalled();
+    expect(startAt).toHaveBeenCalledWith(pageTwoCheckpoint.firstDoc);
+    expect(result.pageCheckpoints[2]).toEqual(pageTwoCheckpoint);
+    expect(result.pageQuery).toBeDefined();
+  });
+
+  test("starts from page 0 when no checkpoints exist", async () => {
+    const fetchDocs = jest
+      .fn()
+      .mockResolvedValueOnce(makeDocsForPage(0))
+      .mockResolvedValueOnce(makeDocsForPage(1));
+
+    const result = await createPaginationRequest({
+      baseQuery,
+      page: 2,
       pageSize: PAGE_SIZE,
       pageCheckpoints: {},
+      fetchDocs,
     });
 
-    const result = request.resolve(makeDocsForPage(0));
-
-    expect(request.pageToCache).toBe(0);
-    expect(request.isTargetPage).toBe(true);
-    expect(result.pageCheckpoints[0].firstDoc.id).toBe("page-0-doc-1");
+    expect(fetchDocs).toHaveBeenCalledTimes(2);
     expect(result.pageCheckpoints[0].lastDoc.id).toBe("page-0-doc-6");
-    expect(result.docs).toHaveLength(PAGE_SIZE);
-  });
-
-  test("resolves an intermediate page during a forward jump without marking it as target", () => {
-    const request = createPaginationRequest({
-      baseQuery,
-      page: 3,
-      pageSize: PAGE_SIZE,
-      pageCheckpoints: {
-        0: makeCheckpointForPage(0),
-      },
-    });
-
-    const result = request.resolve(makeDocsForPage(1));
-
-    expect(request.pageToCache).toBe(1);
-    expect(request.isTargetPage).toBe(false);
-    expect(result.pageCheckpoints[1].firstDoc.id).toBe("page-1-doc-1");
     expect(result.pageCheckpoints[1].lastDoc.id).toBe("page-1-doc-6");
-    expect(result.isTargetPage).toBe(false);
+    expect(startAfter).toHaveBeenLastCalledWith(
+      result.pageCheckpoints[1].lastDoc,
+    );
   });
 
-  test("does not add a checkpoint when resolved docs are empty", () => {
-    // Example: an empty Firestore page leaves the checkpoint cache unchanged.
-    const existingCheckpoint = makeCheckpointForPage(0);
-    const request = createPaginationRequest({
+  test("returns reachedEnd when an intermediate page is empty", async () => {
+    const fetchDocs = jest.fn().mockResolvedValueOnce([]);
+
+    const result = await createPaginationRequest({
       baseQuery,
-      page: 1,
+      page: 2,
       pageSize: PAGE_SIZE,
-      pageCheckpoints: {
-        0: existingCheckpoint,
-      },
+      pageCheckpoints: {},
+      fetchDocs,
     });
 
-    const result = request.resolve([]);
+    expect(result.pageQuery).toBeNull();
+    expect(result.reachedEnd).toBe(true);
+    expect(result.missingPage).toBe(0);
+    expect(result.pageCheckpoints).toEqual({});
+  });
 
-    expect(result.isEmpty).toBe(true);
-    expect(result.pageCheckpoints).toEqual({
-      0: existingCheckpoint,
-    });
+  test("throws when fetchDocs is not provided", async () => {
+    await expect(
+      createPaginationRequest({
+        baseQuery,
+        page: 1,
+        pageSize: PAGE_SIZE,
+      }),
+    ).rejects.toThrow("fetchDocs must be provided.");
   });
 });

--- a/src/__tests__/utils/paginationService.test.js
+++ b/src/__tests__/utils/paginationService.test.js
@@ -4,19 +4,19 @@ import {
 } from "../../utils/buildPaginatedQuery";
 import { getPageCheckpoint } from "../../utils/getPageCheckpoint";
 import { createPaginationRequest } from "../../services/paginationService";
-import { limit, query, startAfter, startAt } from "firebase/firestore";
+import { getDocs, query, startAfter, startAt } from "firebase/firestore";
 
 // Mock Firestore query builders. The tests verify cursor decisions and
 // checkpoint behavior without hitting live Firebase.
 jest.mock("firebase/firestore", () => ({
-  limit: jest.fn(),
+  getDocs: jest.fn(),
   query: jest.fn(),
   startAfter: jest.fn(),
   startAt: jest.fn(),
 }));
 
 const PAGE_SIZE = 6;
-const baseQuery = { collection: "logs" };
+const baseQuery = { collection: "logs", limit: PAGE_SIZE };
 const makeDocsForPage = (page) =>
   Array.from({ length: PAGE_SIZE }, (_, index) => ({
     id: `page-${page}-doc-${index + 1}`,
@@ -25,7 +25,6 @@ const makeDocsForPage = (page) =>
 const makeCheckpointForPage = (page) => getPageCheckpoint(makeDocsForPage(page));
 
 const resetFirestoreMocks = () => {
-  limit.mockImplementation((n) => ({ type: "limit", n }));
   query.mockImplementation((queryBase, ...constraints) => ({
     baseQuery: queryBase,
     constraints,
@@ -80,14 +79,13 @@ describe("buildPaginatedQuery", () => {
     const result = buildPaginatedQuery({
       baseQuery,
       page: 0,
-      pageSize: PAGE_SIZE,
       pageCheckpoints: {},
     });
 
-    expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
+    expect(query).not.toHaveBeenCalled();
     expect(startAt).not.toHaveBeenCalled();
     expect(startAfter).not.toHaveBeenCalled();
-    expect(result.pageQuery).toBeDefined();
+    expect(result.pageQuery).toBe(baseQuery);
     expect(result.isTargetPage).toBeUndefined();
   });
 
@@ -98,14 +96,16 @@ describe("buildPaginatedQuery", () => {
     buildPaginatedQuery({
       baseQuery,
       page: 1,
-      pageSize: PAGE_SIZE,
       pageCheckpoints: {
         1: pageOneCheckpoint,
       },
     });
 
     expect(startAt).toHaveBeenCalledWith(pageOneCheckpoint.firstDoc);
-    expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
+    expect(query).toHaveBeenCalledWith(
+      baseQuery,
+      expect.objectContaining({ type: "startAt" }),
+    );
   });
 
   test("builds missing page query from nearest previous checkpoint", () => {
@@ -115,14 +115,16 @@ describe("buildPaginatedQuery", () => {
     buildPaginatedQuery({
       baseQuery,
       page: 3,
-      pageSize: PAGE_SIZE,
       pageCheckpoints: {
         2: pageTwoCheckpoint,
       },
     });
 
     expect(startAfter).toHaveBeenCalledWith(pageTwoCheckpoint.lastDoc);
-    expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
+    expect(query).toHaveBeenCalledWith(
+      baseQuery,
+      expect.objectContaining({ type: "startAfter" }),
+    );
   });
 
   test("throws for negative pages", () => {
@@ -130,7 +132,6 @@ describe("buildPaginatedQuery", () => {
       buildPaginatedQuery({
         baseQuery,
         page: -1,
-        pageSize: PAGE_SIZE,
       }),
     ).toThrow("Page must be 0 or greater.");
   });
@@ -147,24 +148,21 @@ describe("createPaginationRequest", () => {
     const pageZeroCheckpoint = makeCheckpointForPage(0);
     const pageOneCheckpoint = makeCheckpointForPage(1);
     const pageTwoCheckpoint = makeCheckpointForPage(2);
-    const fetchDocs = jest
-      .fn()
-      .mockResolvedValueOnce(makeDocsForPage(3))
-      .mockResolvedValueOnce(makeDocsForPage(4));
+    getDocs
+      .mockResolvedValueOnce({ docs: makeDocsForPage(3) })
+      .mockResolvedValueOnce({ docs: makeDocsForPage(4) });
 
     const result = await createPaginationRequest({
       baseQuery,
       page: 5,
-      pageSize: PAGE_SIZE,
       pageCheckpoints: {
         0: pageZeroCheckpoint,
         1: pageOneCheckpoint,
         2: pageTwoCheckpoint,
       },
-      fetchDocs,
     });
 
-    expect(fetchDocs).toHaveBeenCalledTimes(2);
+    expect(getDocs).toHaveBeenCalledTimes(2);
     expect(result.pageCheckpoints[3].firstDoc.id).toBe("page-3-doc-1");
     expect(result.pageCheckpoints[3].lastDoc.id).toBe("page-3-doc-6");
     expect(result.pageCheckpoints[4].firstDoc.id).toBe("page-4-doc-1");
@@ -173,45 +171,38 @@ describe("createPaginationRequest", () => {
       result.pageCheckpoints[4].lastDoc,
     );
     expect(result.pageQuery).toBeDefined();
-    expect(result.reachedEnd).toBe(false);
     expect(result.isTargetPage).toBeUndefined();
   });
 
   test("does not fetch intermediate pages when the requested page is already cached", async () => {
     const pageTwoCheckpoint = makeCheckpointForPage(2);
-    const fetchDocs = jest.fn();
 
     const result = await createPaginationRequest({
       baseQuery,
       page: 2,
-      pageSize: PAGE_SIZE,
       pageCheckpoints: {
         2: pageTwoCheckpoint,
       },
-      fetchDocs,
     });
 
-    expect(fetchDocs).not.toHaveBeenCalled();
+    expect(getDocs).not.toHaveBeenCalled();
     expect(startAt).toHaveBeenCalledWith(pageTwoCheckpoint.firstDoc);
     expect(result.pageCheckpoints[2]).toEqual(pageTwoCheckpoint);
     expect(result.pageQuery).toBeDefined();
   });
 
   test("starts from page 0 when no checkpoints exist", async () => {
-    const fetchDocs = jest
-      .fn()
-      .mockResolvedValueOnce(makeDocsForPage(0))
-      .mockResolvedValueOnce(makeDocsForPage(1));
+    getDocs
+      .mockResolvedValueOnce({ docs: makeDocsForPage(0) })
+      .mockResolvedValueOnce({ docs: makeDocsForPage(1) });
 
     const result = await createPaginationRequest({
       baseQuery,
       page: 2,
-      pageSize: PAGE_SIZE,
       pageCheckpoints: {},
-      fetchDocs,
     });
 
-    expect(fetchDocs).toHaveBeenCalledTimes(2);
+    expect(getDocs).toHaveBeenCalledTimes(2);
     expect(result.pageCheckpoints[0].lastDoc.id).toBe("page-0-doc-6");
     expect(result.pageCheckpoints[1].lastDoc.id).toBe("page-1-doc-6");
     expect(startAfter).toHaveBeenLastCalledWith(
@@ -219,30 +210,17 @@ describe("createPaginationRequest", () => {
     );
   });
 
-  test("returns reachedEnd when an intermediate page is empty", async () => {
-    const fetchDocs = jest.fn().mockResolvedValueOnce([]);
+  test("returns null pageQuery when an intermediate page is empty", async () => {
+    getDocs.mockResolvedValueOnce({ docs: [] });
 
     const result = await createPaginationRequest({
       baseQuery,
       page: 2,
-      pageSize: PAGE_SIZE,
       pageCheckpoints: {},
-      fetchDocs,
     });
 
     expect(result.pageQuery).toBeNull();
-    expect(result.reachedEnd).toBe(true);
-    expect(result.missingPage).toBe(0);
     expect(result.pageCheckpoints).toEqual({});
   });
 
-  test("throws when fetchDocs is not provided", async () => {
-    await expect(
-      createPaginationRequest({
-        baseQuery,
-        page: 1,
-        pageSize: PAGE_SIZE,
-      }),
-    ).rejects.toThrow("fetchDocs must be provided.");
-  });
 });

--- a/src/__tests__/utils/paginationService.test.js
+++ b/src/__tests__/utils/paginationService.test.js
@@ -1,0 +1,235 @@
+import { buildPaginatedQuery } from "../../utils/buildPaginatedQuery";
+import { getPageCheckpoint } from "../../utils/getPageCheckpoint";
+import { createPaginationRequest } from "../../services/paginationService";
+import { limit, query, startAfter, startAt } from "firebase/firestore";
+
+// Mock only Firestore query builders. These tests verify cursor decisions,
+// not live Firebase reads or Firestore index behavior.
+// Example: startAfter(doc) returns a plain object so we can assert the cursor.
+jest.mock("firebase/firestore", () => ({
+  limit: jest.fn((n) => ({ type: "limit", n })),
+  query: jest.fn((baseQuery, ...constraints) => ({
+    baseQuery,
+    constraints,
+  })),
+  startAfter: jest.fn((doc) => ({ type: "startAfter", doc })),
+  startAt: jest.fn((doc) => ({ type: "startAt", doc })),
+}));
+
+const PAGE_SIZE = 6;
+const baseQuery = { collection: "logs" };
+const makeDocsForPage = (page) =>
+  Array.from({ length: PAGE_SIZE }, (_, index) => ({
+    id: `page-${page}-doc-${index + 1}`,
+  }));
+
+const makeCheckpointForPage = (page) => getPageCheckpoint(makeDocsForPage(page));
+
+describe("getPageCheckpoint", () => {
+  test("returns first and last docs for a page", () => {
+    // Plain objects are enough here because the helper only stores snapshots.
+    // Example: six fake docs produce firstDoc = doc 1 and lastDoc = doc 6.
+    const checkpoint = getPageCheckpoint(makeDocsForPage(0));
+
+    expect(checkpoint.firstDoc.id).toBe("page-0-doc-1");
+    expect(checkpoint.lastDoc.id).toBe("page-0-doc-6");
+  });
+
+  test("uses the same doc as first and last for a short final page", () => {
+    const checkpoint = getPageCheckpoint([{ id: "page-4-doc-1" }]);
+
+    expect(checkpoint.firstDoc.id).toBe("page-4-doc-1");
+    expect(checkpoint.lastDoc.id).toBe("page-4-doc-1");
+  });
+
+  test("returns null for an empty page", () => {
+    expect(getPageCheckpoint([])).toBeNull();
+  });
+});
+
+describe("buildPaginatedQuery", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("builds first page query without a cursor", () => {
+    const result = buildPaginatedQuery({
+      baseQuery,
+      page: 0,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {},
+    });
+
+    expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
+    expect(startAt).not.toHaveBeenCalled();
+    expect(startAfter).not.toHaveBeenCalled();
+    expect(result.pageToCache).toBe(0);
+    expect(result.isTargetPage).toBe(true);
+  });
+
+  test("builds cached page query with startAt", () => {
+    // Example: if page 1 is cached, we can fetch it directly from its first doc.
+    const pageOneCheckpoint = makeCheckpointForPage(1);
+
+    const result = buildPaginatedQuery({
+      baseQuery,
+      page: 1,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {
+        1: pageOneCheckpoint,
+      },
+    });
+
+    expect(startAt).toHaveBeenCalledWith(pageOneCheckpoint.firstDoc);
+    expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
+    expect(result.pageToCache).toBe(1);
+    expect(result.isTargetPage).toBe(true);
+  });
+
+  test("builds next missing page query with nearest previous checkpoint", () => {
+    // Example: page 1 is fetched with startAfter(page 0's last doc).
+    const pageZeroCheckpoint = makeCheckpointForPage(0);
+
+    const result = buildPaginatedQuery({
+      baseQuery,
+      page: 1,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {
+        0: pageZeroCheckpoint,
+      },
+    });
+
+    expect(startAfter).toHaveBeenCalledWith(pageZeroCheckpoint.lastDoc);
+    expect(limit).toHaveBeenCalledWith(PAGE_SIZE);
+    expect(result.pageToCache).toBe(1);
+    expect(result.isTargetPage).toBe(true);
+  });
+
+  test("returns the first missing page when target page is not reachable yet", () => {
+    // With no checkpoints, page 2 cannot be fetched directly. The service asks
+    // the hook to fetch and cache page 0 first.
+    const result = buildPaginatedQuery({
+      baseQuery,
+      page: 2,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {},
+    });
+
+    expect(startAfter).not.toHaveBeenCalled();
+    expect(result.pageToCache).toBe(0);
+    expect(result.isTargetPage).toBe(false);
+  });
+
+  test("continues from the nearest cached page while jumping forward", () => {
+    // The target is page 3, but page 2 is the next missing page after cache.
+    const pageZeroCheckpoint = makeCheckpointForPage(0);
+    const pageOneCheckpoint = makeCheckpointForPage(1);
+
+    const result = buildPaginatedQuery({
+      baseQuery,
+      page: 3,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {
+        0: pageZeroCheckpoint,
+        1: pageOneCheckpoint,
+      },
+    });
+
+    expect(startAfter).toHaveBeenCalledWith(pageOneCheckpoint.lastDoc);
+    expect(result.pageToCache).toBe(2);
+    expect(result.isTargetPage).toBe(false);
+  });
+
+  test("skips older checkpoints and starts after the nearest cached page", () => {
+    const pageZeroCheckpoint = makeCheckpointForPage(0);
+    const pageTwoCheckpoint = makeCheckpointForPage(2);
+
+    const result = buildPaginatedQuery({
+      baseQuery,
+      page: 4,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {
+        0: pageZeroCheckpoint,
+        2: pageTwoCheckpoint,
+      },
+    });
+
+    expect(startAfter).toHaveBeenCalledWith(pageTwoCheckpoint.lastDoc);
+    expect(result.pageToCache).toBe(3);
+    expect(result.isTargetPage).toBe(false);
+  });
+
+  test("throws for negative pages", () => {
+    expect(() =>
+      buildPaginatedQuery({
+        baseQuery,
+        page: -1,
+        pageSize: PAGE_SIZE,
+      }),
+    ).toThrow("Page must be 0 or greater.");
+  });
+});
+
+describe("createPaginationRequest", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns a page query and resolves docs into updated checkpoints", () => {
+    // The hook will fetch request.pageQuery, then pass snapshot.docs to resolve.
+    // Example: resolving six docs caches page 0 as { firstDoc, lastDoc }.
+    const request = createPaginationRequest({
+      baseQuery,
+      page: 0,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {},
+    });
+
+    const result = request.resolve(makeDocsForPage(0));
+
+    expect(request.pageToCache).toBe(0);
+    expect(request.isTargetPage).toBe(true);
+    expect(result.pageCheckpoints[0].firstDoc.id).toBe("page-0-doc-1");
+    expect(result.pageCheckpoints[0].lastDoc.id).toBe("page-0-doc-6");
+    expect(result.docs).toHaveLength(PAGE_SIZE);
+  });
+
+  test("resolves an intermediate page during a forward jump without marking it as target", () => {
+    const request = createPaginationRequest({
+      baseQuery,
+      page: 3,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {
+        0: makeCheckpointForPage(0),
+      },
+    });
+
+    const result = request.resolve(makeDocsForPage(1));
+
+    expect(request.pageToCache).toBe(1);
+    expect(request.isTargetPage).toBe(false);
+    expect(result.pageCheckpoints[1].firstDoc.id).toBe("page-1-doc-1");
+    expect(result.pageCheckpoints[1].lastDoc.id).toBe("page-1-doc-6");
+    expect(result.isTargetPage).toBe(false);
+  });
+
+  test("does not add a checkpoint when resolved docs are empty", () => {
+    // Example: an empty Firestore page leaves the checkpoint cache unchanged.
+    const existingCheckpoint = makeCheckpointForPage(0);
+    const request = createPaginationRequest({
+      baseQuery,
+      page: 1,
+      pageSize: PAGE_SIZE,
+      pageCheckpoints: {
+        0: existingCheckpoint,
+      },
+    });
+
+    const result = request.resolve([]);
+
+    expect(result.isEmpty).toBe(true);
+    expect(result.pageCheckpoints).toEqual({
+      0: existingCheckpoint,
+    });
+  });
+});

--- a/src/services/paginationService.js
+++ b/src/services/paginationService.js
@@ -1,3 +1,4 @@
+import { getDocs } from "firebase/firestore";
 import {
   buildPaginatedQuery,
   getNearestCachedPageBefore,
@@ -6,13 +7,12 @@ import { getPageCheckpoint } from "../utils/getPageCheckpoint";
 
 // Prepares the target page query and fills any missing prerequisite checkpoints.
 // Example: if pages 0-2 are cached and page 5 is requested, this fetches pages
-// 3 and 4, stores their checkpoints, then returns the page 5 query.
+// 3 and 4, stores their checkpoints, then returns the page 5 query. The
+// incoming baseQuery must already include limit(...), which defines page size.
 export const createPaginationRequest = async ({
   baseQuery,
   page,
-  pageSize,
   pageCheckpoints = {},
-  fetchDocs,
 }) => {
   const updatedCheckpoints = { ...pageCheckpoints };
   const targetPageIsCached = Boolean(updatedCheckpoints[page]?.firstDoc);
@@ -21,14 +21,12 @@ export const createPaginationRequest = async ({
     const { pageQuery } = buildPaginatedQuery({
       baseQuery,
       page,
-      pageSize,
       pageCheckpoints: updatedCheckpoints,
     });
 
     return {
       pageQuery,
       pageCheckpoints: updatedCheckpoints,
-      reachedEnd: false,
     };
   }
 
@@ -38,28 +36,20 @@ export const createPaginationRequest = async ({
   // Fetch only the pages needed to create a cursor for the requested page.
   // Example: target page 5 requires checkpoints through page 4.
   for (let pageToCache = firstMissingPage; pageToCache < page; pageToCache += 1) {
-    if (typeof fetchDocs !== "function") {
-      throw new Error("fetchDocs must be provided.");
-    }
-
-    if (updatedCheckpoints[pageToCache]?.lastDoc) continue;
-
     const { pageQuery } = buildPaginatedQuery({
       baseQuery,
       page: pageToCache,
-      pageSize,
       pageCheckpoints: updatedCheckpoints,
     });
 
-    const docs = await fetchDocs(pageQuery);
+    const snapshot = await getDocs(pageQuery);
+    const docs = snapshot.docs;
     const checkpoint = getPageCheckpoint(docs);
 
     if (!checkpoint) {
       return {
         pageQuery: null,
         pageCheckpoints: updatedCheckpoints,
-        reachedEnd: true,
-        missingPage: pageToCache,
       };
     }
 
@@ -69,13 +59,11 @@ export const createPaginationRequest = async ({
   const { pageQuery } = buildPaginatedQuery({
     baseQuery,
     page,
-    pageSize,
     pageCheckpoints: updatedCheckpoints,
   });
 
   return {
     pageQuery,
     pageCheckpoints: updatedCheckpoints,
-    reachedEnd: false,
   };
 };

--- a/src/services/paginationService.js
+++ b/src/services/paginationService.js
@@ -1,49 +1,81 @@
-import { buildPaginatedQuery } from "../utils/buildPaginatedQuery";
+import {
+  buildPaginatedQuery,
+  getNearestCachedPageBefore,
+} from "../utils/buildPaginatedQuery";
 import { getPageCheckpoint } from "../utils/getPageCheckpoint";
 
-// Public pagination boundary for hooks/components. It decides which Firestore
-// query should be fetched next and packages checkpoint updates into resolve().
-//
-// Example:
-// const request = createPaginationRequest({ baseQuery, page: 2, pageSize: 6, pageCheckpoints });
-// const snapshot = await getDocs(request.pageQuery);
-// const result = request.resolve(snapshot.docs);
-export const createPaginationRequest = ({
+// Prepares the target page query and fills any missing prerequisite checkpoints.
+// Example: if pages 0-2 are cached and page 5 is requested, this fetches pages
+// 3 and 4, stores their checkpoints, then returns the page 5 query.
+export const createPaginationRequest = async ({
   baseQuery,
   page,
   pageSize,
   pageCheckpoints = {},
+  fetchDocs,
 }) => {
-  const { pageQuery, pageToCache, isTargetPage } = buildPaginatedQuery({
+  const updatedCheckpoints = { ...pageCheckpoints };
+  const targetPageIsCached = Boolean(updatedCheckpoints[page]?.firstDoc);
+
+  if (targetPageIsCached) {
+    const { pageQuery } = buildPaginatedQuery({
+      baseQuery,
+      page,
+      pageSize,
+      pageCheckpoints: updatedCheckpoints,
+    });
+
+    return {
+      pageQuery,
+      pageCheckpoints: updatedCheckpoints,
+      reachedEnd: false,
+    };
+  }
+
+  const nearestCachedPage = getNearestCachedPageBefore(page, updatedCheckpoints);
+  const firstMissingPage = nearestCachedPage === null ? 0 : nearestCachedPage + 1;
+
+  // Fetch only the pages needed to create a cursor for the requested page.
+  // Example: target page 5 requires checkpoints through page 4.
+  for (let pageToCache = firstMissingPage; pageToCache < page; pageToCache += 1) {
+    if (typeof fetchDocs !== "function") {
+      throw new Error("fetchDocs must be provided.");
+    }
+
+    if (updatedCheckpoints[pageToCache]?.lastDoc) continue;
+
+    const { pageQuery } = buildPaginatedQuery({
+      baseQuery,
+      page: pageToCache,
+      pageSize,
+      pageCheckpoints: updatedCheckpoints,
+    });
+
+    const docs = await fetchDocs(pageQuery);
+    const checkpoint = getPageCheckpoint(docs);
+
+    if (!checkpoint) {
+      return {
+        pageQuery: null,
+        pageCheckpoints: updatedCheckpoints,
+        reachedEnd: true,
+        missingPage: pageToCache,
+      };
+    }
+
+    updatedCheckpoints[pageToCache] = checkpoint;
+  }
+
+  const { pageQuery } = buildPaginatedQuery({
     baseQuery,
     page,
     pageSize,
-    pageCheckpoints,
+    pageCheckpoints: updatedCheckpoints,
   });
 
   return {
     pageQuery,
-    pageToCache,
-    isTargetPage,
-    // The hook fetches pageQuery with getDocs(), then passes snapshot.docs here.
-    // This keeps Firestore reads in the hook while hiding checkpoint bookkeeping.
-    // Example: resolve([docA, docB]) returns updated pageCheckpoints for pageToCache.
-    resolve: (docs) => {
-      const checkpoint = getPageCheckpoint(docs);
-
-      return {
-        docs,
-        checkpoint,
-        pageToCache,
-        isTargetPage,
-        isEmpty: checkpoint === null,
-        pageCheckpoints: checkpoint
-          ? {
-              ...pageCheckpoints,
-              [pageToCache]: checkpoint,
-            }
-          : { ...pageCheckpoints },
-      };
-    },
+    pageCheckpoints: updatedCheckpoints,
+    reachedEnd: false,
   };
 };

--- a/src/services/paginationService.js
+++ b/src/services/paginationService.js
@@ -1,0 +1,49 @@
+import { buildPaginatedQuery } from "../utils/buildPaginatedQuery";
+import { getPageCheckpoint } from "../utils/getPageCheckpoint";
+
+// Public pagination boundary for hooks/components. It decides which Firestore
+// query should be fetched next and packages checkpoint updates into resolve().
+//
+// Example:
+// const request = createPaginationRequest({ baseQuery, page: 2, pageSize: 6, pageCheckpoints });
+// const snapshot = await getDocs(request.pageQuery);
+// const result = request.resolve(snapshot.docs);
+export const createPaginationRequest = ({
+  baseQuery,
+  page,
+  pageSize,
+  pageCheckpoints = {},
+}) => {
+  const { pageQuery, pageToCache, isTargetPage } = buildPaginatedQuery({
+    baseQuery,
+    page,
+    pageSize,
+    pageCheckpoints,
+  });
+
+  return {
+    pageQuery,
+    pageToCache,
+    isTargetPage,
+    // The hook fetches pageQuery with getDocs(), then passes snapshot.docs here.
+    // This keeps Firestore reads in the hook while hiding checkpoint bookkeeping.
+    // Example: resolve([docA, docB]) returns updated pageCheckpoints for pageToCache.
+    resolve: (docs) => {
+      const checkpoint = getPageCheckpoint(docs);
+
+      return {
+        docs,
+        checkpoint,
+        pageToCache,
+        isTargetPage,
+        isEmpty: checkpoint === null,
+        pageCheckpoints: checkpoint
+          ? {
+              ...pageCheckpoints,
+              [pageToCache]: checkpoint,
+            }
+          : { ...pageCheckpoints },
+      };
+    },
+  };
+};

--- a/src/utils/buildPaginatedQuery.js
+++ b/src/utils/buildPaginatedQuery.js
@@ -3,7 +3,7 @@ import { limit, query, startAfter, startAt } from "firebase/firestore";
 // Firestore cursor pagination needs a known document snapshot before it can
 // fetch a later page. This finds the closest cached page behind the target.
 // Example: target page 4 with cached pages 0 and 2 returns 2.
-const getNearestCachedPageBefore = (page, pageCheckpoints) => {
+export const getNearestCachedPageBefore = (page, pageCheckpoints) => {
   for (let cursorPage = page - 1; cursorPage >= 0; cursorPage -= 1) {
     if (pageCheckpoints[cursorPage]?.lastDoc) {
       return cursorPage;
@@ -33,8 +33,6 @@ export const buildPaginatedQuery = ({
         startAt(pageCheckpoints[page].firstDoc),
         limit(pageSize),
       ),
-      pageToCache: page,
-      isTargetPage: true,
     };
   }
 
@@ -43,24 +41,19 @@ export const buildPaginatedQuery = ({
   if (page === 0) {
     return {
       pageQuery: query(baseQuery, limit(pageSize)),
-      pageToCache: 0,
-      isTargetPage: true,
     };
   }
 
   const cachedPage = getNearestCachedPageBefore(page, pageCheckpoints);
-  const pageToCache = cachedPage === null ? 0 : cachedPage + 1;
   const cursor =
     cachedPage === null ? null : pageCheckpoints[cachedPage].lastDoc;
 
-  // If the target page is not directly reachable yet, this returns the next
-  // missing page. The hook/service caller can fetch and cache it, then ask again.
-  // Example: target page 3 with only page 1 cached returns pageToCache 2.
+  // If the requested page is not directly cached, start after the nearest
+  // previous checkpoint. The service makes sure prerequisite checkpoints exist.
+  // Example: target page 3 with page 2 cached uses startAfter(page2.lastDoc).
   return {
     pageQuery: cursor
       ? query(baseQuery, startAfter(cursor), limit(pageSize))
       : query(baseQuery, limit(pageSize)),
-    pageToCache,
-    isTargetPage: pageToCache === page,
   };
 };

--- a/src/utils/buildPaginatedQuery.js
+++ b/src/utils/buildPaginatedQuery.js
@@ -1,4 +1,4 @@
-import { limit, query, startAfter, startAt } from "firebase/firestore";
+import { query, startAfter, startAt } from "firebase/firestore";
 
 // Firestore cursor pagination needs a known document snapshot before it can
 // fetch a later page. This finds the closest cached page behind the target.
@@ -16,7 +16,6 @@ export const getNearestCachedPageBefore = (page, pageCheckpoints) => {
 export const buildPaginatedQuery = ({
   baseQuery,
   page,
-  pageSize,
   pageCheckpoints = {},
 }) => {
   if (page < 0) {
@@ -31,16 +30,15 @@ export const buildPaginatedQuery = ({
       pageQuery: query(
         baseQuery,
         startAt(pageCheckpoints[page].firstDoc),
-        limit(pageSize),
       ),
     };
   }
 
   // Page zero never needs a cursor.
-  // Example: page 0 always becomes query(baseQuery, limit(pageSize)).
+  // Example: page 0 is just the baseQuery, which already includes limit(...).
   if (page === 0) {
     return {
-      pageQuery: query(baseQuery, limit(pageSize)),
+      pageQuery: baseQuery,
     };
   }
 
@@ -53,7 +51,7 @@ export const buildPaginatedQuery = ({
   // Example: target page 3 with page 2 cached uses startAfter(page2.lastDoc).
   return {
     pageQuery: cursor
-      ? query(baseQuery, startAfter(cursor), limit(pageSize))
-      : query(baseQuery, limit(pageSize)),
+      ? query(baseQuery, startAfter(cursor))
+      : baseQuery,
   };
 };

--- a/src/utils/buildPaginatedQuery.js
+++ b/src/utils/buildPaginatedQuery.js
@@ -1,0 +1,66 @@
+import { limit, query, startAfter, startAt } from "firebase/firestore";
+
+// Firestore cursor pagination needs a known document snapshot before it can
+// fetch a later page. This finds the closest cached page behind the target.
+// Example: target page 4 with cached pages 0 and 2 returns 2.
+const getNearestCachedPageBefore = (page, pageCheckpoints) => {
+  for (let cursorPage = page - 1; cursorPage >= 0; cursorPage -= 1) {
+    if (pageCheckpoints[cursorPage]?.lastDoc) {
+      return cursorPage;
+    }
+  }
+
+  return null;
+};
+
+export const buildPaginatedQuery = ({
+  baseQuery,
+  page,
+  pageSize,
+  pageCheckpoints = {},
+}) => {
+  if (page < 0) {
+    throw new Error("Page must be 0 or greater.");
+  }
+
+  // If the target page is already checkpointed, fetch from its first doc.
+  // This refreshes the page data without walking from earlier pages.
+  // Example: pageCheckpoints[2] exists, so fetch page 2 with startAt(firstDoc).
+  if (pageCheckpoints[page]?.firstDoc) {
+    return {
+      pageQuery: query(
+        baseQuery,
+        startAt(pageCheckpoints[page].firstDoc),
+        limit(pageSize),
+      ),
+      pageToCache: page,
+      isTargetPage: true,
+    };
+  }
+
+  // Page zero never needs a cursor.
+  // Example: page 0 always becomes query(baseQuery, limit(pageSize)).
+  if (page === 0) {
+    return {
+      pageQuery: query(baseQuery, limit(pageSize)),
+      pageToCache: 0,
+      isTargetPage: true,
+    };
+  }
+
+  const cachedPage = getNearestCachedPageBefore(page, pageCheckpoints);
+  const pageToCache = cachedPage === null ? 0 : cachedPage + 1;
+  const cursor =
+    cachedPage === null ? null : pageCheckpoints[cachedPage].lastDoc;
+
+  // If the target page is not directly reachable yet, this returns the next
+  // missing page. The hook/service caller can fetch and cache it, then ask again.
+  // Example: target page 3 with only page 1 cached returns pageToCache 2.
+  return {
+    pageQuery: cursor
+      ? query(baseQuery, startAfter(cursor), limit(pageSize))
+      : query(baseQuery, limit(pageSize)),
+    pageToCache,
+    isTargetPage: pageToCache === page,
+  };
+};

--- a/src/utils/getPageCheckpoint.js
+++ b/src/utils/getPageCheckpoint.js
@@ -1,0 +1,11 @@
+// Store only the document snapshots needed as Firestore cursor anchors.
+// The actual card data should be handled separately by the hook/component.
+// Example: [docA, docB, docC] becomes { firstDoc: docA, lastDoc: docC }.
+export const getPageCheckpoint = (docs) => {
+  if (!docs.length) return null;
+
+  return {
+    firstDoc: docs[0],
+    lastDoc: docs[docs.length - 1],
+  };
+};


### PR DESCRIPTION
## Summary

Adds a modular pagination service for Firestore cursor-based pagination.

This PR introduces reusable pagination helpers that can later be consumed by a `usePagination` hook and shared across pages that display paginated cards or records.

## Changes

- Added `src/services/paginationService.js`
  - Provides `createPaginationRequest`
  - Builds the next Firestore query request
  - Handles checkpoint generation through `resolve(docs)`

- Added `src/utils/buildPaginatedQuery.js`
  - Contains pure query-building logic
  - Supports cached pages, first page fetches, and forward jumps through missing checkpoints

- Added `src/utils/getPageCheckpoint.js`
  - Extracts `{ firstDoc, lastDoc }` from fetched Firestore docs

- Added `src/__tests__/utils/paginationService.test.js`
  - Tests checkpoint generation
  - Tests query-building behavior
  - Tests service request resolution
  - Uses six-document page fixtures for clearer pagination behavior

## Testing

Ran:

```bash
npm test -- --watchAll=false paginationService
